### PR TITLE
DM-30169: Define flat tests for cp_verify

### DIFF
--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -1,8 +1,10 @@
-name: lint
+name: Lint YAML Files
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   lint:
@@ -16,7 +18,7 @@ jobs:
           python-version: 3.8
 
       - name: Install
-        run: pip install -r <(curl https://raw.githubusercontent.com/lsst/linting/master/requirements.txt)
+        run: pip install yamllint
 
       - name: Run linter
-        run: flake8
+        run: yamllint .

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,14 @@
+extends: default
+
+rules:
+  document-start: {present: false}
+  line-length:
+    max: 132
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+    ignore: |
+      /.github/workflows/lint.yaml
+  truthy:
+    # "on" as a key in workflows confuses things
+    ignore: |
+      /.github/workflows/

--- a/pipelines/VerifyBias.yaml
+++ b/pipelines/VerifyBias.yaml
@@ -5,25 +5,25 @@ tasks:
     config:
       connections.ccdExposure: 'raw'
       connections.outputExposure: 'verifyBiasProc'
-      doBias: True
-      doVariance: True
-      doLinearize: False
-      doCrosstalk: False
-      doDefect: True
-      doNanMasking: True
-      doInterpolate: True
-      doBrighterFatter: False
-      doDark: False
-      doFlat: False
-      doApplyGains: False
-      doFringe: False
+      doBias: true
+      doVariance: true
+      doLinearize: false
+      doCrosstalk: false
+      doDefect: true
+      doNanMasking: true
+      doInterpolate: true
+      doBrighterFatter: false
+      doDark: false
+      doFlat: false
+      doApplyGains: false
+      doFringe: false
   verifyMeasureStats:
     class: lsst.cp.verify.CpVerifyBiasTask
     config:
       connections.inputExp: 'verifyBiasProc'
       connections.outputStats: 'verifyBiasDetStats'
-      doVignette: False
-      useReadNoise: True
+      doVignette: false
+      useReadNoise: true
   verifyExposureStats:
     class: lsst.cp.verify.CpVerifyExpMergeTask
     config:

--- a/pipelines/VerifyDark.yaml
+++ b/pipelines/VerifyDark.yaml
@@ -6,10 +6,10 @@ tasks:
       connections.ccdExposure: 'raw'
       connections.outputExposure: 'verifyDarkProc'
       # Disable downstream processing.
-      doDark: True
-      doFlat: False
-      doApplyGains: False
-      doFringe: False
+      doDark: true
+      doFlat: false
+      doApplyGains: false
+      doFringe: false
   verifyDarkChip:
     class: lsst.cp.verify.CpVerifyDarkTask
     config:

--- a/pipelines/VerifyDefectPostFlat.yaml
+++ b/pipelines/VerifyDefectPostFlat.yaml
@@ -1,0 +1,41 @@
+description: cp_verify DEFECT calibration verification
+tasks:
+  verifyDefectApply:
+    class: lsst.ip.isr.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'verifyDefectProc'
+      overscan.fitType: 'MEDIAN_PER_ROW'
+      doWrite: True
+      doOverscan: True
+      doAssembleCcd: True
+      doBias: True
+      doVariance: False
+      doLinearize: False
+      doCrosstalk: False
+      doBrighterFatter: False
+      doDark: True
+      doStrayLight: False
+      doFlat: True
+      doFringe: False
+      doApplyGains: False
+      doDefect: True
+      doSaturationInterpolation: False
+      growSaturationFootprintSize: 0
+  verifyMeasureStats:
+    class: lsst.cp.verify.CpVerifyDefectsTask
+    config:
+      connections.inputExp: 'verifyDefectProc'
+      connections.outputStats: 'verifyDefectDetStats'
+      doVignette: False
+      useReadNoise: False
+  verifyExposureStats:
+    class: lsst.cp.verify.CpVerifyExpMergeTask
+    config:
+      connections.inputStats: 'verifyDefectDetStats'
+      connections.outputStats: 'verifyDefectExpStats'
+  verifyRunStats:
+    class: lsst.cp.verify.CpVerifyRunMergeTask
+    config:
+      connections.inputStats: 'verifyDefectExpStats'
+      connections.outputStats: 'verifyDefectStats'

--- a/pipelines/VerifyDefectPostFlat.yaml
+++ b/pipelines/VerifyDefectPostFlat.yaml
@@ -6,29 +6,29 @@ tasks:
       connections.ccdExposure: 'raw'
       connections.outputExposure: 'verifyDefectProc'
       overscan.fitType: 'MEDIAN_PER_ROW'
-      doWrite: True
-      doOverscan: True
-      doAssembleCcd: True
-      doBias: True
-      doVariance: False
-      doLinearize: False
-      doCrosstalk: False
-      doBrighterFatter: False
-      doDark: True
-      doStrayLight: False
-      doFlat: True
-      doFringe: False
-      doApplyGains: False
-      doDefect: True
-      doSaturationInterpolation: False
+      doWrite: true
+      doOverscan: true
+      doAssembleCcd: true
+      doBias: true
+      doVariance: false
+      doLinearize: false
+      doCrosstalk: false
+      doBrighterFatter: false
+      doDark: true
+      doStrayLight: false
+      doFlat: true
+      doFringe: false
+      doApplyGains: false
+      doDefect: true
+      doSaturationInterpolation: false
       growSaturationFootprintSize: 0
   verifyMeasureStats:
     class: lsst.cp.verify.CpVerifyDefectsTask
     config:
       connections.inputExp: 'verifyDefectProc'
       connections.outputStats: 'verifyDefectDetStats'
-      doVignette: False
-      useReadNoise: False
+      doVignette: false
+      useReadNoise: false
   verifyExposureStats:
     class: lsst.cp.verify.CpVerifyExpMergeTask
     config:

--- a/pipelines/VerifyFlat.yaml
+++ b/pipelines/VerifyFlat.yaml
@@ -6,8 +6,8 @@ tasks:
       connections.ccdExposure: 'raw'
       connections.outputExposure: 'verifyFlatProc'
       # Disable downstream processing.
-      doApplyGains: False
-      doFringe: False
+      doApplyGains: false
+      doFringe: false
   verifyFlatChip:
     class: lsst.cp.verify.CpVerifyFlatTask
     config:

--- a/pipelines/VerifyFlat.yaml
+++ b/pipelines/VerifyFlat.yaml
@@ -1,0 +1,25 @@
+description: cp_verify FLAT calibration verification
+tasks:
+  verifyFlatApply:
+    class: lsst.ip.isr.isrTask.IsrTask
+    config:
+      connections.ccdExposure: 'raw'
+      connections.outputExposure: 'verifyFlatProc'
+      # Disable downstream processing.
+      doApplyGains: False
+      doFringe: False
+  verifyFlatChip:
+    class: lsst.cp.verify.CpVerifyFlatTask
+    config:
+      connections.inputExp: 'verifyFlatProc'
+      connections.outputStats: 'verifyFlatDetStats'
+  verifyFlatExp:
+    class: lsst.cp.verify.CpVerifyExpMergeTask
+    config:
+      connections.inputStats: 'verifyFlatDetStats'
+      connections.outputStats: 'verifyFlatExpStats'
+  verifyFlat:
+    class: lsst.cp.verify.CpVerifyRunMergeTask
+    config:
+      connections.inputStats: 'verifyFlatExpStats'
+      connections.outputStats: 'verifyFlatStats'

--- a/python/lsst/cp/verify/__init__.py
+++ b/python/lsst/cp/verify/__init__.py
@@ -24,6 +24,6 @@ from .verifyStats import *
 from .mergeResults import *
 
 from .verifyBias import *
-from .verifyDark import *
 from .verifyDefects import *
-
+from .verifyDark import *
+from .verifyFlat import *

--- a/python/lsst/cp/verify/mergeResults.py
+++ b/python/lsst/cp/verify/mergeResults.py
@@ -179,7 +179,7 @@ class CpVerifyExpMergeTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
 
         Parameters
         ----------
-        statisticsDIctionary : `dict [`str`, `dict` [`str`, scalar]],
+        statisticsDictionary : `dict [`str`, `dict` [`str`, scalar]],
             Dictionary of measured statistics.  The top level
             dictionary is keyed on the detector names, and contains
             the measured statistics from the per-detector
@@ -190,7 +190,7 @@ class CpVerifyExpMergeTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         outputStatistics : `dict` [`str, scalar]
             A dictionary of the statistics measured and their values.
         """
-        raise NotImplementedError("Subclasses must implement verification criteria. CZW??")
+        raise NotImplementedError("Subclasses must implement verification criteria.")
 
     def verify(self, detectorStatistics, statisticsDictionary):
 

--- a/python/lsst/cp/verify/verifyFlat.py
+++ b/python/lsst/cp/verify/verifyFlat.py
@@ -53,7 +53,7 @@ class CpVerifyFlatTask(CpVerifyStatsTask):
 
         Parameters
         ----------
-        statisticsDictionary : `dict` [`str`, `dict` [`str`, scalar]],
+        statisticsDict : `dict` [`str`, `dict` [`str`, scalar]],
             Dictionary of measured statistics.  The inner dictionary
             should have keys that are statistic names (`str`) with
             values that are some sort of scalar (`int` or `float` are
@@ -85,7 +85,7 @@ class CpVerifyFlatTask(CpVerifyStatsTask):
         ----------
         exposure : `lsst.afw.image.Exposure`
             The exposure the statistics are from.
-        statisticsDictionary : `dict` [`str`, `dict` [`str`, scalar]],
+        statisticsDict : `dict` [`str`, `dict` [`str`, scalar]],
             Dictionary of measured statistics.  The inner dictionary
             should have keys that are statistic names (`str`) with
             values that are some sort of scalar (`int` or `float` are

--- a/python/lsst/cp/verify/verifyFlat.py
+++ b/python/lsst/cp/verify/verifyFlat.py
@@ -131,6 +131,7 @@ class CpVerifyFlatTask(CpVerifyStatsTask):
 class CpVerifyFlatExpMergeConfig(CpVerifyExpMergeConfig):
     """Inherits from base CpVerifyExpMergeConfig
     """
+
     def setDefaults(self):
         super().setDefaults()
         self.exposureStatKeywords = {'EXPOSURE_SCATTER': 'STDEV',  # noqa F841
@@ -141,12 +142,25 @@ class CpVerifyFlatExpMergeTask(CpVerifyExpMergeTask):
     """Inherits from base CpVerifyExpMergeTask
     """
 
-    def exposureStatistics(self, mergedStatistics):
-        """XXX
-        """
+    def exposureStatistics(self, statisticsDictionary):
+        """Calculate exposure level statistics based on the existing
+        per-amplifier and per-detector measurements.
 
+        Parameters
+        ----------
+        statisticsDictionary : `dict [`str`, `dict` [`str`, scalar]],
+            Dictionary of measured statistics.  The top level
+            dictionary is keyed on the detector names, and contains
+            the measured statistics from the per-detector
+            measurements.
+
+        Returns
+        -------
+        outputStatistics : `dict` [`str, scalar]
+            A dictionary of the statistics measured and their values.
+        """
         detectorMeans = []
-        for detName, stats in mergedStatistics.items():
+        for detName, stats in statisticsDictionary.items():
             # Get detector stats:
             detectorMeans.append(stats['DET']['MEAN'])
 

--- a/python/lsst/cp/verify/verifyFlat.py
+++ b/python/lsst/cp/verify/verifyFlat.py
@@ -1,0 +1,185 @@
+# This file is part of cp_verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import numpy as np
+import lsst.afw.math as afwMath
+from .verifyStats import CpVerifyStatsConfig, CpVerifyStatsTask, CpVerifyStatsConnections
+from .mergeResults import CpVerifyExpMergeConfig, CpVerifyExpMergeTask
+
+__all__ = ['CpVerifyFlatConfig', 'CpVerifyFlatTask',
+           'CpVerifyFlatExpMergeConfig', 'CpVerifyFlatExpMergeTask']
+# 'CpVerifyFlatRunMergeConfig', 'CpVerifyFlatRunMergeTask',]
+
+
+class CpVerifyFlatConfig(CpVerifyStatsConfig,
+                         pipelineConnections=CpVerifyStatsConnections):
+    """Inherits from base CpVerifyStatsConfig.
+    """
+
+    def setDefaults(self):
+        super().setDefaults()
+        self.imageStatKeywords = {'MEAN': 'MEAN',  # noqa F841
+                                  'NOISE': 'STDEVCLIP', }
+        self.detectorStatKeywords = {'MEAN': 'MEAN',  # noqa F841
+                                     'SCATTER': 'STDEV', }
+
+
+class CpVerifyFlatTask(CpVerifyStatsTask):
+    """Flat verification sub-class, implementing the verify method.
+    """
+    ConfigClass = CpVerifyFlatConfig
+    _DefaultName = 'cpVerifyFlat'
+
+    def detectorStatistics(self, statisticsDict, statControl):
+        """Calculate detector level statistics based on the existing
+        per-amplifier measurements.
+
+        Parameters
+        ----------
+        statisticsDictionary : `dict` [`str`, `dict` [`str`, scalar]],
+            Dictionary of measured statistics.  The inner dictionary
+            should have keys that are statistic names (`str`) with
+            values that are some sort of scalar (`int` or `float` are
+            the mostly likely types).
+
+        Returns
+        -------
+        outputStatistics : `dict` [`str`, scalar]
+            A dictionary of the statistics measured and their values.
+
+        """
+        outputStatistics = {}
+
+        ampStats = statisticsDict['AMP']
+        amplifierMeans = [stats['MEAN'] for stats in ampStats.values()]
+
+        statisticToRun, statAccessor = self._configHelper(self.config.detectorStatKeywords)
+        stats = afwMath.makeStatistics(amplifierMeans, statisticToRun, statControl)
+
+        for k, v in statAccessor.items():
+            outputStatistics[k] = stats.getValue(v)
+
+        return outputStatistics
+
+    def verify(self, exposure, statisticsDict):
+        """Verify that the measured statistics meet the verification criteria.
+
+        Parameters
+        ----------
+        exposure : `lsst.afw.image.Exposure`
+            The exposure the statistics are from.
+        statisticsDictionary : `dict` [`str`, `dict` [`str`, scalar]],
+            Dictionary of measured statistics.  The inner dictionary
+            should have keys that are statistic names (`str`) with
+            values that are some sort of scalar (`int` or `float` are
+            the mostly likely types).
+
+        Returns
+        -------
+        outputStatistics : `dict` [`str`, `dict` [`str`, `bool`]]
+            A dictionary indexed by the amplifier name, containing
+            dictionaries of the verification criteria.
+        success : `bool`
+            A boolean indicating if all tests have passed.
+        """
+        ampStats = statisticsDict['AMP']
+        verifyStats = {}
+        success = True
+        for ampName, stats in ampStats.items():
+            verify = {}
+
+            # DMTN-101 Test 10.X: confirm that per-amplifier scatter is
+            #                     consistent with Poissonian
+            verify['NOISE'] = bool(np.abs(stats['NOISE']) <= np.sqrt(stats['MEAN']))
+
+            verify['SUCCESS'] = bool(np.all(list(verify.values())))
+            if verify['SUCCESS'] is False:
+                success = False
+
+            verifyStats[ampName] = verify
+
+        verifyDet = {}
+        detStats = statisticsDict['DET']
+
+        # DMTN-101 Test 10.Y: confirm intra-chip scatter is small.
+        verifyDet['SCATTER'] = bool(detStats['SCATTER']/detStats['MEAN'] <= 0.05)
+
+        verifyDet['SUCCESS'] = bool(np.all(list(verifyDet.values())))
+        if verifyDet['SUCCESS'] is False:
+            success = False
+
+        return {'AMP': verifyStats, 'DET': verifyDet}, bool(success)
+
+
+class CpVerifyFlatExpMergeConfig(CpVerifyExpMergeConfig):
+    """Inherits from base CpVerifyExpMergeConfig
+    """
+    def setDefaults(self):
+        super().setDefaults()
+        self.exposureStatKeywords = {'EXPOSURE_SCATTER': 'STDEV',  # noqa F841
+                                     }
+
+
+class CpVerifyFlatExpMergeTask(CpVerifyExpMergeTask):
+    """Inherits from base CpVerifyExpMergeTask
+    """
+
+    def exposureStatistics(self, mergedStatistics):
+        """XXX
+        """
+
+        detectorMeans = []
+        for detName, stats in mergedStatistics.items():
+            # Get detector stats:
+            detectorMeans.append(stats['DET']['MEAN'])
+
+        return {'SCATTER': np.stdev(detectorMeans)}
+
+    def verify(self, detectorStatistics, statisticsDictionary):
+        """Verify if the measured statistics meet the verification criteria.
+
+        Parameters
+        ----------
+        detectorStatistics : `dict` [`str`, `dict` [`str`, scalar]]
+            Merged set of input detector level statistics.
+        statisticsDictionary : `dict` [`str`, `dict` [`str`, scalar]],
+            Dictionary of measured statistics.  The inner dictionary
+            should have keys that are statistic names (`str`) with
+            values that are some sort of scalar (`int` or `float` are
+            the mostly likely types).
+
+        Returns
+        -------
+        outputStatistics : `dict` [`str`, `dict` [`str`, `bool`]]
+            A dictionary indexed by the amplifier name, containing
+            dictionaries of the verification criteria.
+        success : `bool`
+            A boolean indicating if all tests have passed.
+
+        """
+        verifyStats = {}
+        success = True
+
+        # DMTN-101 Test 10.Z: confirm inter-chip scatter is small.
+        verifyStats['SCATTER'] = bool(statisticsDictionary['EXP']['SCATTER'] <= 0.05)
+
+        success = bool(np.all(list(verifyStats.values())))
+
+        return {'EXP': verifyStats}, bool(success)

--- a/python/lsst/cp/verify/verifyStats.py
+++ b/python/lsst/cp/verify/verifyStats.py
@@ -323,6 +323,36 @@ class CpVerifyStatsTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
 
         return outputStatistics
 
+    @staticmethod
+    def _configHelper(keywordDict):
+        """Helper to convert keyword dictionary to stat value.
+
+        Convert the string names in the keywordDict to the afwMath values.
+        The statisticToRun is then the bitwise-or of that set.
+
+        Parameters
+        ----------
+        keywordDict : `dict` [`str`, `str`]
+            A dictionary of keys to use in the output results, with
+            values the string name associated with the
+            `lsst.afw.math.statistics.Property` to measure.
+
+        Returns
+        -------
+        statisticToRun : `int`
+            The merged `lsst.afw.math` statistics property.
+        statAccessor : `dict` [`str`, `int`]
+            Dictionary containing statistics property indexed by name.
+        """
+        statisticToRun = 0
+        statAccessor = {}
+        for k, v in keywordDict.items():
+            statValue = afwMath.stringToStatisticsProperty(v)
+            statisticToRun |= statValue
+            statAccessor[k] = statValue
+
+        return statisticToRun, statAccessor
+
     def amplifierStats(self, exposure, keywordDict, statControl):
         """Measure amplifier level statistics from the exposure.
 
@@ -346,14 +376,7 @@ class CpVerifyStatsTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         """
         ampStats = {}
 
-        # Convert the string names in the keywordDict to the afwMath values.
-        # The statisticToRun is then the bitwise-or of that set.
-        statisticToRun = 0
-        statAccessor = {}
-        for k, v in keywordDict.items():
-            statValue = afwMath.stringToStatisticsProperty(v)
-            statisticToRun |= statValue
-            statAccessor[k] = statValue
+        statisticToRun, statAccessor = self._configHelper(keywordDict)
 
         # Measure stats on all amplifiers.
         for ampIdx, amp in enumerate(exposure.getDetector()):

--- a/ups/cp_verify.table
+++ b/ups/cp_verify.table
@@ -5,7 +5,6 @@ setupRequired(ip_isr)
 setupRequired(meas_algorithms)
 setupRequired(pex_config)
 setupRequired(pex_exceptions)
-setupRequired(pipe_base)
 setupRequired(pipe_tasks)
 setupRequired(utils)
 


### PR DESCRIPTION
This defines an initial set of flat verification tests:

1. Per amplfier noise should be consistent with a Poissonian distribution.
2. Amplifiers on one detector should have the same mean level.
3. Detectors in an exposure should have the same mean level.

Additional helper code is added, as well as the ability to measure per-exposure statistics.