### PR TITLE
DM-31692: Fix edge handling in cp_verify CR cases

### DIFF
--- a/python/lsst/cp/verify/verifyStats.py
+++ b/python/lsst/cp/verify/verifyStats.py
@@ -472,6 +472,7 @@ class CpVerifyStatsTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
             crMask = crRejectedExp.getMaskedImage().getMask().getPlaneBitMask("CR")
             spans = afwGeom.SpanSet.fromMask(crRejectedExp.mask, crMask)
             spans = spans.dilated(self.config.crGrow)
+            spans = spans.clippedTo(crRejectedExp.getBBox())
             spans.setMask(crRejectedExp.mask, crMask)
 
         return self.amplifierStats(crRejectedExp, self.config.crImageStatKeywords, statControl)


### PR DESCRIPTION
Grown CR spans should fit on the source image; clip them to be sure.