### PR TITLE
DM-32470: Dark verification in OCPS calibration script from DM-31897 fails because NOISe is too low with respect nominal readnoise

### DIFF
--- a/pipelines/VerifyBias.yaml
+++ b/pipelines/VerifyBias.yaml
@@ -22,6 +22,7 @@ tasks:
     class: lsst.cp.verify.CpVerifyBiasTask
     config:
       connections.inputExp: 'verifyBiasProc'
+      connections.taskMetadata: 'verifyBiasApply_metadata'
       connections.outputStats: 'verifyBiasDetStats'
       doVignette: false
       useReadNoise: true

--- a/pipelines/VerifyDark.yaml
+++ b/pipelines/VerifyDark.yaml
@@ -15,6 +15,7 @@ tasks:
     class: lsst.cp.verify.CpVerifyDarkTask
     config:
       connections.inputExp: 'verifyDarkProc'
+      connections.taskMetadata: 'verifyDarkApply_metadata'
       connections.outputStats: 'verifyDarkDetStats'
   verifyDarkExp:
     class: lsst.cp.verify.CpVerifyExpMergeTask

--- a/python/lsst/cp/verify/verifyBias.py
+++ b/python/lsst/cp/verify/verifyBias.py
@@ -35,7 +35,6 @@ class CpVerifyBiasConfig(CpVerifyStatsConfig,
         super().setDefaults()
         self.imageStatKeywords = {'MEAN': 'MEAN',  # noqa F841
                                   'NOISE': 'STDEVCLIP', }
-
         self.crImageStatKeywords = {'CR_NOISE': 'STDEV', }  # noqa F841
         self.metadataStatKeywords = {'RESIDUAL STDEV': 'AMP', }  # noqa F841
 
@@ -80,12 +79,22 @@ class CpVerifyBiasTask(CpVerifyStatsTask):
             verify['MEAN'] = bool(np.abs(stats['MEAN']) < stats['NOISE'])
 
             # DMTN-101 Test 4.3: Clipped mean matches readNoise.
+            # The read noise from the detector object may not match
+            # the read noise of the camera taking the images. If
+            # possible, pull the residual remaining after the serial
+            # overscan has been overscan corrected from the task
+            # metadata (stored with the key f"RESIDUAL STDEV {ampName}").
+            # This should provide a measurement of the actual read
+            # noise in the exposure.  A test below (that does not
+            # trigger failure) will note if the detector read noise
+            # matched the measured read noise.
             readNoise = detector[ampName].getReadNoise()
             if 'RESIDUAL STDEV' in metadataStats and ampName in metadataStats['RESIDUAL STDEV']:
                 overscanReadNoise = metadataStats['RESIDUAL STDEV'][ampName]
-                if ((overscanReadNoise - readNoise)/readNoise > 0.05):
-                    readNoiseMatch = False
-                readNoise = overscanReadNoise
+                if overscanReadNoise:
+                    if ((overscanReadNoise - readNoise)/readNoise > 0.05):
+                        readNoiseMatch = False
+                    readNoise = overscanReadNoise
 
             verify['NOISE'] = bool(np.abs(stats['NOISE'] - readNoise)/readNoise <= 0.05)
 
@@ -99,7 +108,8 @@ class CpVerifyBiasTask(CpVerifyStatsTask):
             verify['SUCCESS'] = bool(np.all(list(verify.values())))
             if verify['SUCCESS'] is False:
                 success = False
-            # This isn't something to fail on yet.
+            # This is a notice so we can track the read noise
+            # stability.  We shouldn't fail on it.
             verify['READ_NOISE_CONSISTENT'] = readNoiseMatch
 
             verifyStats[ampName] = verify

--- a/python/lsst/cp/verify/verifyDark.py
+++ b/python/lsst/cp/verify/verifyDark.py
@@ -79,6 +79,15 @@ class CpVerifyDarkTask(CpVerifyStatsTask):
             verify['MEAN'] = bool(np.abs(stats['MEAN']) < stats['NOISE'])
 
             # DMTN-101 Test 5.3: Clipped mean matches readNoise
+            # The read noise from the detector object may not match
+            # the read noise of the camera taking the images. If
+            # possible, pull the residual remaining after the serial
+            # overscan has been overscan corrected from the task
+            # metadata (stored with the key f"RESIDUAL STDEV {ampName}").
+            # This should provide a measurement of the actual read
+            # noise in the exposure.  A test below (that does not
+            # trigger failure) will note if the detector read noise
+            # matched the measured read noise.
             readNoise = detector[ampName].getReadNoise()
             if 'RESIDUAL STDEV' in metadataStats and ampName in metadataStats['RESIDUAL STDEV']:
                 overscanReadNoise = metadataStats['RESIDUAL STDEV'][ampName]
@@ -99,7 +108,8 @@ class CpVerifyDarkTask(CpVerifyStatsTask):
             verify['SUCCESS'] = bool(np.all(list(verify.values())))
             if verify['SUCCESS'] is False:
                 success = False
-            # This isn't something to fail on yet.
+            # This is a notice so we can track the read noise
+            # stability.  We shouldn't fail on it.
             verify['READ_NOISE_CONSISTENT'] = readNoiseMatch
 
             verifyStats[ampName] = verify

--- a/python/lsst/cp/verify/verifyStats.py
+++ b/python/lsst/cp/verify/verifyStats.py
@@ -66,6 +66,12 @@ class CpVerifyStatsConnections(pipeBase.PipelineTaskConnections,
         dimensions=["instrument", "exposure", "detector"],
     )
 
+    def __init__(self, *, config=None):
+        super().__init__(config=config)
+
+        if len(config.metadataStatKeywords) < 1:
+            self.inputs.discard('taskMetadata')
+
 
 class CpVerifyStatsConfig(pipeBase.PipelineTaskConfig,
                           pipelineConnections=CpVerifyStatsConnections):

--- a/python/lsst/cp/verify/verifyStats.py
+++ b/python/lsst/cp/verify/verifyStats.py
@@ -32,6 +32,7 @@ from lsst.cp.pipe.cpCombine import vignetteExposure
 from lsst.pipe.tasks.repair import RepairTask
 from .utils import mergeStatDict
 
+
 __all__ = ['CpVerifyStatsConfig', 'CpVerifyStatsTask']
 
 
@@ -42,6 +43,12 @@ class CpVerifyStatsConnections(pipeBase.PipelineTaskConnections,
         name="postISRCCD",
         doc="Input exposure to calculate statistics for.",
         storageClass="Exposure",
+        dimensions=["instrument", "exposure", "detector"],
+    )
+    taskMetadata = cT.Input(
+        name="isrTask_metadata",
+        doc="Input task metadata to extract statistics from.",
+        storageClass="PropertySet",
         dimensions=["instrument", "exposure", "detector"],
     )
     camera = cT.PrerequisiteInput(
@@ -148,6 +155,12 @@ class CpVerifyStatsConfig(pipeBase.PipelineTaskConfig,
         doc="Image statistics to run on expTime normalized amplifier segments.",
         default={},
     )
+    metadataStatKeywords = pexConfig.DictField(
+        keytype=str,
+        itemtype=str,
+        doc="Statistics to measure from the metadata of the exposure.",
+        default={},
+    )
     catalogStatKeywords = pexConfig.DictField(
         keytype=str,
         itemtype=str,
@@ -176,7 +189,7 @@ class CpVerifyStatsTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         super().__init__(**kwargs)
         self.makeSubtask("repair")
 
-    def run(self, inputExp, camera):
+    def run(self, inputExp, camera, taskMetadata=None):
         """Calculate quality statistics and verify they meet the requirements
         for a calibration.
 
@@ -184,6 +197,8 @@ class CpVerifyStatsTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         ----------
         inputExp : `lsst.afw.image.Exposure`
             The ISR processed exposure to be measured.
+        taskMetadata : `lsst.daf.base.PropertySet`, optional
+            Task metadata containing additional statistics.
         camera : `lsst.afw.cameraGeom.Camera`
              The camera geometry for ``inputExp``.
 
@@ -239,6 +254,13 @@ class CpVerifyStatsTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         # This is wrapped below to check for config lengths, as we can
         # make a number of different image stats.
         outputStats['AMP'] = self.imageStatistics(inputExp, statControl)
+
+        if len(self.config.metadataStatKeywords):
+            # These are also defined on a amp-by-amp basis.
+            outputStats['METADATA'] = self.metadataStatistics(inputExp, taskMetadata)
+        else:
+            outputStats['METADATA'] = {}
+
         if len(self.config.catalogStatKeywords):
             outputStats['CATALOG'] = self.catalogStatistics(inputExp, statControl)
         else:
@@ -310,7 +332,6 @@ class CpVerifyStatsTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                                              self.amplifierStats(exposure,
                                                                  self.config.imageStatKeywords,
                                                                  statControl))
-
         if len(self.config.unmaskedImageStatKeywords):
             outputStatistics = mergeStatDict(outputStatistics, self.unmaskedImageStats(exposure))
 
@@ -353,6 +374,44 @@ class CpVerifyStatsTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
             statAccessor[k] = statValue
 
         return statisticToRun, statAccessor
+
+    def metadataStatistics(self, exposure, taskMetadata):
+        """Extract task metadata information for verification.
+
+        Parameters
+        ----------
+        exposure : `lsst.afw.image.Exposure`
+            The exposure to measure.
+        taskMetadata : `lsst.daf.base.PropertySet`
+            The metadata to extract values from.
+
+        Returns
+        -------
+        ampStats : `dict` [`str`, `dict` [`str`, scalar]]
+            A dictionary indexed by the amplifier name, containing
+            dictionaries of the statistics measured and their values.
+        """
+        metadataStats = {}
+        keywordDict = self.config.metadataStatKeywords
+
+        if taskMetadata:
+            for key, value in keywordDict.items():
+                if value == 'AMP':
+                    metadataStats[key] = {}
+                    for ampIdx, amp in enumerate(exposure.getDetector()):
+                        ampName = amp.getName()
+                        expectedKey = f"{key} {ampName}"
+                        metadataStats[key][ampName] = None
+                        for name in taskMetadata.names():
+                            if expectedKey in taskMetadata[name]:
+                                metadataStats[key][ampName] = taskMetadata[name][expectedKey]
+                else:
+                    # Assume it's detector-wide.
+                    expectedKey = key
+                    for name in taskMetadata.names():
+                        if expectedKey in taskMetadata[name]:
+                            metadataStats[key] = taskMetadata[name][expectedKey]
+        return metadataStats
 
     def amplifierStats(self, exposure, keywordDict, statControl, failAll=False):
         """Measure amplifier level statistics from the exposure.


### PR DESCRIPTION
This change adds the possibility of pulling values from the task metadata.  This code path is then used to pull the measured scatter in the overscan as an estimate the read noise.  This should resolve the issue of the camera read noise not matching the quoted camera value.