### PR TITLE
DM-29326: Fix logic of the doVignette option in isrTask

### DIFF
--- a/python/lsst/cp/verify/verifyDefects.py
+++ b/python/lsst/cp/verify/verifyDefects.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import numpy as np
-import scipy
+import scipy.stats
 
 from .verifyStats import CpVerifyStatsConfig, CpVerifyStatsTask, CpVerifyStatsConnections
 

--- a/python/lsst/cp/verify/verifyStats.py
+++ b/python/lsst/cp/verify/verifyStats.py
@@ -28,7 +28,7 @@ import lsst.pipe.base as pipeBase
 import lsst.pipe.base.connectionTypes as cT
 import lsst.meas.algorithms as measAlg
 
-from lsst.cp.pipe.cpCombine import vignetteExposure
+from lsst.ip.isr.vignette import maskVignettedRegion
 from lsst.pipe.tasks.repair import RepairTask
 from .utils import mergeStatDict
 
@@ -248,8 +248,9 @@ class CpVerifyStatsTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
         outputStats = {}
 
         if self.config.doVignette:
-            vignetteExposure(inputExp, doUpdateMask=True, maskPlane='NO_DATA',
-                             doSetValue=False, log=self.log)
+            polygon = inputExp.getInfo().getValidPolygon()
+            maskVignettedRegion(inputExp, polygon, maskPlane='NO_DATA',
+                                vignetteValue=None, log=self.log)
 
         mask = inputExp.getMask()
         maskVal = mask.getPlaneBitMask(self.config.maskNameList)


### PR DESCRIPTION
I missed a vignette case here.

This also fixes a new build error related to scipy.