### PR TITLE
DM-32682: Use more general APIs for task metadata

### DIFF
--- a/python/lsst/cp/verify/verifyStats.py
+++ b/python/lsst/cp/verify/verifyStats.py
@@ -409,13 +409,13 @@ class CpVerifyStatsTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                         ampName = amp.getName()
                         expectedKey = f"{key} {ampName}"
                         metadataStats[key][ampName] = None
-                        for name in taskMetadata.names():
+                        for name in taskMetadata:
                             if expectedKey in taskMetadata[name]:
                                 metadataStats[key][ampName] = taskMetadata[name][expectedKey]
                 else:
                     # Assume it's detector-wide.
                     expectedKey = key
-                    for name in taskMetadata.names():
+                    for name in taskMetadata:
                         if expectedKey in taskMetadata[name]:
                             metadataStats[key] = taskMetadata[name][expectedKey]
         return metadataStats

--- a/tests/test_verifyStats.py
+++ b/tests/test_verifyStats.py
@@ -27,8 +27,6 @@ import lsst.ip.isr.isrMock as isrMock
 import lsst.cp.verify as cpVerify
 import lsst.ip.isr.isrFunctions as isrFunctions
 
-from lsst.daf.base import PropertySet
-
 
 def updateMockExp(exposure, addCR=True):
     """Update an exposure with a mask and variance plane.
@@ -186,11 +184,11 @@ class VerifyDarkTestCase(lsst.utils.tests.TestCase):
 
         # Use this to test the metadataStats code, as this is the case
         # it's designed to fix.
-        metadataContents = PropertySet()
-        metadataContents.setFloat("RESIDUAL STDEV C:0,0", 12.0)
-        metadataContents.setFloat("RESIDUAL STDEV", 24.0)
-        self.metadata = PropertySet()
-        self.metadata.setPropertySet("subGroup", metadataContents)
+        metadataContents = {}
+        metadataContents["RESIDUAL STDEV C:0,0"] = 12.0
+        metadataContents["RESIDUAL STDEV"] = 24.0
+        self.metadata = {}
+        self.metadata["subGroup"] = metadataContents
 
         self.camera = isrMock.IsrMock().getCamera()
 

--- a/tests/test_verifyStats.py
+++ b/tests/test_verifyStats.py
@@ -27,6 +27,8 @@ import lsst.ip.isr.isrMock as isrMock
 import lsst.cp.verify as cpVerify
 import lsst.ip.isr.isrFunctions as isrFunctions
 
+from lsst.pipe.base import TaskMetadata
+
 
 def updateMockExp(exposure, addCR=True):
     """Update an exposure with a mask and variance plane.
@@ -184,10 +186,10 @@ class VerifyDarkTestCase(lsst.utils.tests.TestCase):
 
         # Use this to test the metadataStats code, as this is the case
         # it's designed to fix.
-        metadataContents = {}
+        metadataContents = TaskMetadata()
         metadataContents["RESIDUAL STDEV C:0,0"] = 12.0
         metadataContents["RESIDUAL STDEV"] = 24.0
-        self.metadata = {}
+        self.metadata = TaskMetadata()
         self.metadata["subGroup"] = metadataContents
 
         self.camera = isrMock.IsrMock().getCamera()


### PR DESCRIPTION
This makes things more compatible with the upcoming TaskMetadata class.

One wrinkle here is that the pipeline requires task metadata so when we migrate away from PropertySet we will have to remember to change the pipeline storage class definition.