### PR TITLE
DM-33300: Drop connections that aren't needed in cp_verify

### DIFF
--- a/python/lsst/cp/verify/verifyStats.py
+++ b/python/lsst/cp/verify/verifyStats.py
@@ -84,6 +84,10 @@ class CpVerifyStatsConnections(pipeBase.PipelineTaskConnections,
         if len(config.metadataStatKeywords) < 1:
             self.inputs.discard('taskMetadata')
 
+        if len(config.catalogStatKeywords) < 1:
+            self.inputs.discard('inputCatalog')
+            self.inputs.discard('uncorrectedCatalog')
+
 
 class CpVerifyStatsConfig(pipeBase.PipelineTaskConfig,
                           pipelineConnections=CpVerifyStatsConnections):


### PR DESCRIPTION
Discard catalog inputs when no catalog input is needed.