### PR TITLE
DM-36747: cp_verify noise checks cannot deal with measured noise smaller than the nominal read noise

### DIFF
--- a/python/lsst/cp/verify/verifyBias.py
+++ b/python/lsst/cp/verify/verifyBias.py
@@ -96,7 +96,7 @@ class CpVerifyBiasTask(CpVerifyStatsTask):
                         readNoiseMatch = False
                     readNoise = overscanReadNoise
 
-            verify['NOISE'] = bool(np.abs(stats['NOISE'] - readNoise)/readNoise <= 0.05)
+            verify['NOISE'] = bool((stats['NOISE'] - readNoise)/readNoise <= 0.05)
 
             # DMTN-101 Test 4.4: CR rejection matches clipped mean.
             verify['CR_NOISE'] = bool(np.abs(stats['NOISE'] - stats['CR_NOISE'])/stats['CR_NOISE'] <= 0.05)

--- a/python/lsst/cp/verify/verifyDark.py
+++ b/python/lsst/cp/verify/verifyDark.py
@@ -96,7 +96,7 @@ class CpVerifyDarkTask(CpVerifyStatsTask):
                         readNoiseMatch = False
                     readNoise = overscanReadNoise
 
-            verify['NOISE'] = bool(np.abs(stats['NOISE'] - readNoise)/readNoise <= 0.05)
+            verify['NOISE'] = bool((stats['NOISE'] - readNoise)/readNoise <= 0.05)
 
             # DMTN-101 Test 5.4: CR rejection matches clipped mean
             verify['CR_NOISE'] = bool(np.abs(stats['NOISE'] - stats['CR_NOISE'])/stats['CR_NOISE'] <= 0.05)

--- a/python/lsst/cp/verify/verifyFlat.py
+++ b/python/lsst/cp/verify/verifyFlat.py
@@ -107,7 +107,7 @@ class CpVerifyFlatTask(CpVerifyStatsTask):
 
             # DMTN-101 Test 10.X: confirm that per-amplifier scatter is
             #                     consistent with Poissonian
-            verify['NOISE'] = bool(np.abs(stats['NOISE']) <= np.sqrt(stats['MEAN']))
+            verify['NOISE'] = bool(stats['NOISE'] <= np.sqrt(stats['MEAN']))
 
             verify['SUCCESS'] = bool(np.all(list(verify.values())))
             if verify['SUCCESS'] is False:


### PR DESCRIPTION
Remove abs calls in NOISE tests.