### PR TITLE
DM-33557:  Add cp_verify tests to ci_cpp

### DIFF
--- a/pipelines/Latiss/VerifyLinearity.yaml
+++ b/pipelines/Latiss/VerifyLinearity.yaml
@@ -2,3 +2,8 @@ description: cp_verify LINEARITY calibration verification
 instrument: lsst.obs.lsst.Latiss
 imports:
   - location: $CP_VERIFY_DIR/pipelines/_ingredients/VerifyLinearity.yaml
+tasks:
+  verifyLinearitySecondLinearizer:
+    class: lsst.cp.verify.verifyLinearity.CpvLinearitySolveTask
+    config:
+      linearityType: "Spline"

--- a/pipelines/_ingredients/VerifyBfk.yaml
+++ b/pipelines/_ingredients/VerifyBfk.yaml
@@ -13,6 +13,7 @@ tasks:
       connections.exposure: 'verifyBfkIsr'
       doApCorr: false
       doDeblend: false
+      doMeasurePsf: false
   verifyUncorrectedBfkIsr:
     class: lsst.ip.isr.isrTask.IsrTask
     config:
@@ -30,6 +31,7 @@ tasks:
       connections.outputSchema: 'verifyUncorrBfk_schema'
       doApCorr: false
       doDeblend: false
+      doMeasurePsf: false
   verifyBfkChip:
     class: lsst.cp.verify.verifyBfk.CpVerifyBfkTask
     config:

--- a/python/lsst/cp/verify/verifyBfk.py
+++ b/python/lsst/cp/verify/verifyBfk.py
@@ -137,11 +137,13 @@ class CpVerifyBfkTask(CpVerifyStatsTask):
             outputStatistics['SIZE_DIFF'] = sizeDiff
             return outputStatistics
 
+        xxKey = 'ext_shapeHSM_HsmSourceMoments_xx'
+        yyKey = 'ext_shapeHSM_HsmSourceMoments_yy'
         for source, uncorrectedSource, d in matches:
             # This uses the simple difference in source moments.
             sourceMagnitude = -2.5 * np.log10(source.getPsfInstFlux())
-            sourceSize = source['base_SdssShape_xx'] + source['base_SdssShape_yy']
-            uncorrectedSize = uncorrectedSource['base_SdssShape_xx'] + uncorrectedSource['base_SdssShape_yy']
+            sourceSize = source[xxKey] + source[yyKey]
+            uncorrectedSize = uncorrectedSource[xxKey] + uncorrectedSource[yyKey]
 
             magnitude.append(float(sourceMagnitude))
             sizeDiff.append(float(uncorrectedSize - sourceSize))

--- a/python/lsst/cp/verify/verifyCalib.py
+++ b/python/lsst/cp/verify/verifyCalib.py
@@ -38,7 +38,7 @@ class CpVerifyCalibConnections(pipeBase.PipelineTaskConnections,
         deferLoad=True,
     )
 
-    inputCalib = cT.Input(
+    inputCalib = cT.PrerequisiteInput(
         name="calib",
         doc="Input calib to calculate statistics for.",
         storageClass="IsrCalib",

--- a/python/lsst/cp/verify/verifyLinearity.py
+++ b/python/lsst/cp/verify/verifyLinearity.py
@@ -239,15 +239,6 @@ class CpvLinearitySolveConnections(pipeBase.PipelineTaskConnections,
         dimensions=("instrument", "detector"),
         isCalibration=True,
     )
-    inputPhotodiodeData = cT.PrerequisiteInput(
-        name="photodiode",
-        doc="Photodiode readings data.",
-        storageClass="IsrCalib",
-        dimensions=("instrument", "exposure"),
-        multiple=True,
-        deferLoad=True,
-        minimum=0,
-    )
     inputPhotodiodeCorrection = cT.Input(
         name="cpvPdCorrection",
         doc="Input photodiode correction.",
@@ -269,9 +260,6 @@ class CpvLinearitySolveConnections(pipeBase.PipelineTaskConnections,
 
         if config.applyPhotodiodeCorrection is not True:
             self.inputs.discard("inputPhotodiodeCorrection")
-
-        if config.usePhotodiode is not True:
-            self.inputs.discard("inputPhotodiodeData")
 
 
 class CpvLinearitySolveConfig(cpPipe.LinearitySolveConfig,

--- a/python/lsst/cp/verify/verifyPtc.py
+++ b/python/lsst/cp/verify/verifyPtc.py
@@ -21,22 +21,9 @@
 import numpy as np
 import lsst.pex.config as pexConfig
 
-import lsst.pipe.base.connectionTypes as cT
 from .verifyCalib import CpVerifyCalibConfig, CpVerifyCalibTask, CpVerifyCalibConnections
 
-__all__ = ['CpVerifyPtcConnections', 'CpVerifyPtcConfig', 'CpVerifyPtcTask']
-
-
-class CpVerifyPtcConnections(CpVerifyCalibConnections,
-                             dimensions={"instrument", "detector"},
-                             defaultTemplates={}):
-    inputCalib = cT.Input(
-        name="calib",
-        doc="Input calib to calculate statistics for.",
-        storageClass="PhotonTransferCurveDataset",
-        dimensions=["instrument", "detector"],
-        isCalibration=True
-    )
+__all__ = ['CpVerifyPtcConfig', 'CpVerifyPtcTask']
 
 
 class CpVerifyPtcConfig(CpVerifyCalibConfig,

--- a/python/lsst/cp/verify/verifyPtc.py
+++ b/python/lsst/cp/verify/verifyPtc.py
@@ -40,7 +40,7 @@ class CpVerifyPtcConnections(CpVerifyCalibConnections,
 
 
 class CpVerifyPtcConfig(CpVerifyCalibConfig,
-                        pipelineConnections=CpVerifyPtcConnections):
+                        pipelineConnections=CpVerifyCalibConnections):
     """Inherits from base CpVerifyCalibConfig."""
 
     def setDefaults(self):
@@ -143,10 +143,9 @@ class CpVerifyPtcTask(CpVerifyCalibTask):
             outputStatistics[ampName]['PTC_TURNOFF'] = inputCalib.ptcTurnoff[ampName]
             outputStatistics[ampName]['PTC_FIT_TYPE'] = ptcFitType
             if ptcFitType == 'EXPAPPROXIMATION':
-                outputStatistics[ampName]['PTC_BFE_A00'] = inputCalib.ptcFitPars[ampName][0]
+                outputStatistics[ampName]['PTC_BFE_A00'] = float(inputCalib.ptcFitPars[ampName][0])
             if ptcFitType == 'FULLCOVARIANCE':
-                outputStatistics[ampName]['PTC_BFE_A00'] = inputCalib.aMatrix[ampName][0][0]
-
+                outputStatistics[ampName]['PTC_BFE_A00'] = float(inputCalib.aMatrix[ampName][0][0])
         return outputStatistics
 
     def verify(self, calib, statisticsDict, camera=None):


### PR DESCRIPTION
* Fix PTC verify results not being writable to yaml
* Remove unneeded photodiode connection.
* Disable PSF measurement in brighter-fatter verification.  Switch shape measurement used.
* Ensure the correct linearity model is used.