### PR TITLE
DM-41633:  Generate empty~SDSSi_65mm flat for LATISS

### DIFF
--- a/python/lsst/cp/verify/verifyDefects.py
+++ b/python/lsst/cp/verify/verifyDefects.py
@@ -156,21 +156,19 @@ class CpVerifyDefectsTask(CpVerifyStatsTask):
 
         return outputStatistics
 
-    def detectorStatistics(self, statsDict, statControl, exposure, uncorrectedExposure):
+    def detectorStatistics(self, statisticsDict, statControl, exposure=None, uncorrectedExposure=None):
         """Measure the detector statistics.
 
         Parameters
         ----------
-        statsDict : `dict` [`str`, scalar]
+        statisticsDict : `dict` [`str`, scalar]
             Dictionary with detector tests.
-        exposure : `lsst.afw.image.Exposure`
-            Exposure containing the ISR processed data to measure.
         statControl : `lsst.afw.math.StatControl`
             Statistics control object with parameters defined by
             the config.
-        exposure : `lsst.afw.image.Exposure`
+        exposure : `lsst.afw.image.Exposure`, optional
             Exposure containing the ISR-processed data to measure.
-        uncorrectedExposure : `lsst.afw.image.Exposure`
+        uncorrectedExposure : `lsst.afw.image.Exposure`, optional
             uncorrected esposure (no defects) containing the
             ISR-processed data to measure.
 

--- a/python/lsst/cp/verify/verifyFlat.py
+++ b/python/lsst/cp/verify/verifyFlat.py
@@ -47,7 +47,7 @@ class CpVerifyFlatTask(CpVerifyStatsTask):
     ConfigClass = CpVerifyFlatConfig
     _DefaultName = 'cpVerifyFlat'
 
-    def detectorStatistics(self, statisticsDict, statControl):
+    def detectorStatistics(self, statisticsDict, statControl, exposure=None, uncorrectedExposure=None):
         """Calculate detector level statistics based on the existing
         per-amplifier measurements.
 
@@ -58,6 +58,14 @@ class CpVerifyFlatTask(CpVerifyStatsTask):
             should have keys that are statistic names (`str`) with
             values that are some sort of scalar (`int` or `float` are
             the mostly likely types).
+        statControl : `lsst.afw.math.StatControl`
+            Statistics control object with parameters defined by
+            the config.
+        exposure : `lsst.afw.image.Exposure`, optional
+            Exposure containing the ISR-processed data to measure.
+        uncorrectedExposure : `lsst.afw.image.Exposure`, optional
+            uncorrected esposure (no defects) containing the
+            ISR-processed data to measure.
 
         Returns
         -------

--- a/python/lsst/cp/verify/verifyStats.py
+++ b/python/lsst/cp/verify/verifyStats.py
@@ -673,11 +673,19 @@ class CpVerifyStatsTask(pipeBase.PipelineTask):
 
         Parameters
         ----------
-        statisticsDictionary : `dict` [`str`, `dict` [`str`, scalar]],
+        statisticsDict : `dict` [`str`, scalar]
             Dictionary of measured statistics.  The inner dictionary
             should have keys that are statistic names (`str`) with
             values that are some sort of scalar (`int` or `float` are
             the mostly likely types).
+        statControl : `lsst.afw.math.StatControl`
+            Statistics control object with parameters defined by
+            the config.
+        exposure : `lsst.afw.image.Exposure`, optional
+            Exposure containing the ISR-processed data to measure.
+        uncorrectedExposure : `lsst.afw.image.Exposure`, optional
+            uncorrected esposure (no defects) containing the
+            ISR-processed data to measure.
 
         Returns
         -------


### PR DESCRIPTION
Fix detectorStatistics for verifyFlat.

Unify the signature and docstring for that method everywhere it is defined for VerifyStatsTask classes.