### PR TITLE
DM-42159:  eo_pipe/cp_verify parity: bias

### DIFF
--- a/pipelines/_ingredients/VerifyBias.yaml
+++ b/pipelines/_ingredients/VerifyBias.yaml
@@ -21,6 +21,8 @@ tasks:
       doCalculateStatistics: true
       isrStats.doCopyCalibDistributionStatistics: true
       isrStats.doProjectionStatistics: true
+      isrStats.doBiasShiftStatistics: true
+      isrStats.doAmplifierCorrelationStatistics: true
   verifyMeasureStats:
     class: lsst.cp.verify.CpVerifyBiasTask
     config:

--- a/python/lsst/cp/verify/verifyBias.py
+++ b/python/lsst/cp/verify/verifyBias.py
@@ -58,7 +58,6 @@ class CpVerifyBiasTask(CpVerifyStatsTask):
         # Docstring inherited
         outputStatistics = super().imageStatistics(exposure, uncorrectedExposure, statControl)
 
-        # These should be a config item, probably.
         boxSize = self.config.ampCornerBoxSize
         statisticToRun = afwMath.stringToStatisticsProperty("MEAN")
 

--- a/python/lsst/cp/verify/verifyBias.py
+++ b/python/lsst/cp/verify/verifyBias.py
@@ -20,8 +20,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import numpy as np
 
+import lsst.afw.math as afwMath
+
+from lsst.geom import Point2I, Extent2I, Box2I
+from lsst.pex.config import Field
 from .verifyStats import CpVerifyStatsConfig, CpVerifyStatsTask, CpVerifyStatsConnections
-from lsst.afw.cameraGeom import ReadoutCorner
 
 __all__ = ['CpVerifyBiasConfig', 'CpVerifyBiasTask']
 
@@ -30,6 +33,12 @@ class CpVerifyBiasConfig(CpVerifyStatsConfig,
                          pipelineConnections=CpVerifyStatsConnections):
     """Inherits from base CpVerifyStatsConfig.
     """
+
+    ampCornerBoxSize = Field(
+        dtype=int,
+        doc="Size of box to use for measure corner signal.",
+        default=200,
+    )
 
     def setDefaults(self):
         super().setDefaults()
@@ -51,18 +60,18 @@ class CpVerifyBiasTask(CpVerifyStatsTask):
 
         theseStats = {}
         # These should be a config item, probably.
-        boxSize = 200
+        boxSize = self.config.ampCornerBoxSize
         statisticToRun = afwMath.stringToStatisticsProperty("MEAN")
 
         for ampIdx, amp in enumerate(exposure.getDetector()):
             ampName = amp.getName()
 
             bbox = amp.getBBox()
-            xmin = bbox.getMaxX() - boxSize if raw_amp.getRawFlipX() else bbox.getMinX()
-            ymin = bbox.getMaxY() - boxSize if raw_amp.getRawFlipY() else bbox.getMinY()
-            llc = lsst.geom.Point2I(xmin, ymin)
-            extent = lsst.geom.Extent2I(boxSize, boxSize)
-            cornerBox = lsst.geom.Box2I(llc, extent)
+            xmin = bbox.getMaxX() - boxSize if amp.getRawFlipX() else bbox.getMinX()
+            ymin = bbox.getMaxY() - boxSize if amp.getRawFlipY() else bbox.getMinY()
+            llc = Point2I(xmin, ymin)
+            extent = Extent2I(boxSize, boxSize)
+            cornerBox = Box2I(llc, extent)
             cornerExp = exposure[cornerBox]
 
             stats = afwMath.makeStatistics(

--- a/python/lsst/cp/verify/verifyBias.py
+++ b/python/lsst/cp/verify/verifyBias.py
@@ -58,7 +58,6 @@ class CpVerifyBiasTask(CpVerifyStatsTask):
         # Docstring inherited
         outputStatistics = super().imageStatistics(exposure, uncorrectedExposure, statControl)
 
-        theseStats = {}
         # These should be a config item, probably.
         boxSize = self.config.ampCornerBoxSize
         statisticToRun = afwMath.stringToStatisticsProperty("MEAN")
@@ -77,9 +76,7 @@ class CpVerifyBiasTask(CpVerifyStatsTask):
             stats = afwMath.makeStatistics(
                 cornerExp.getMaskedImage(), statisticToRun, statControl
             )
-            theseStats[ampName] = stats.getValue()
-
-        outputStatistics['AMP_CORNER'] = theseStats
+            outputStatistics[ampName]['AMP_CORNER'] = stats.getValue()
 
         return outputStatistics
 

--- a/tests/test_verifyStats.py
+++ b/tests/test_verifyStats.py
@@ -154,6 +154,7 @@ class VerifyBiasTestCase(lsst.utils.tests.TestCase):
         """
         config = cpVerify.CpVerifyBiasConfig()
         config.numSigmaClip = 3.0
+        config.ampCornerBoxSize = 15
         task = cpVerify.CpVerifyBiasTask(config=config)
         results = task.run(self.inputExp, self.camera)
         biasStats = results.outputStats


### PR DESCRIPTION
This ticket adds:
 * Code to calculate readout corner mean values.
 * Updated handlers for PTC data.