### PR TITLE
DM-45105: Fix incompatible dataset type definitions for verifyDefectsIndividualIsrExp and verifyDefectsPostFlatIsrExp

### DIFF
--- a/pipelines/_ingredients/verifyDefectsIndividual.yaml
+++ b/pipelines/_ingredients/verifyDefectsIndividual.yaml
@@ -22,31 +22,74 @@ tasks:
       growSaturationFootprintSize: 0
       doCalculateStatistics: true
       isrStats.doCopyCalibDistributionStatistics: true
+  verifyDefectsIndividualChar:
+    class: lsst.pipe.tasks.characterizeImage.CharacterizeImageTask
+    config:
+      connections.exposure: "verifyDefectsIndividualIsrExp"
+      connections.characterized: "verifyDefectsIndividualIcExp"
+      connections.sourceCat: "verifyDefectsIndividualIcSrc"
+      doApCorr: false
+      doDeblend: false
+      doNormalizedCalibration: false
+  verifyUncorrectedDefectsIndividualIsr:
+    class: lsst.ip.isr.IsrTask
+    config:
+      connections.ccdExposure: "raw"
+      connections.outputExposure: "verifyUncorrectedDefectsIndividualIsrExp"
+      doDefect: false
+      doCrosstalk: true
+  verifyUncorrectedDefectsIndividualChar:
+    class: lsst.pipe.tasks.characterizeImage.CharacterizeImageTask
+    config:
+      connections.exposure: "verifyUncorrectedDefectsIndividualIsrExp"
+      connections.characterized: "verifyUncorrectedDefectsIndividualIcExp"
+      connections.sourceCat: "verifyUncorrectedDefectsIndividualIcSrc"
+      connections.backgroundModel: "verifyUncorrectedDefectsIndividualBackground"
+      connections.outputSchema: "verifyUncorrectedDefectsIndividual_schema"
+      doApCorr: false
+      doDeblend: false
+      doMeasurePsf: false
+      doNormalizedCalibration: false
   verifyDefectsIndividualDet:
     class: lsst.cp.verify.CpVerifyDefectsTask
     config:
-      connections.inputExp: "verifyDefectsIndividualIsrExp"
+      connections.inputExp: "verifyDefectsIndividualIcExp"
+      connections.uncorrectedExp: "verifyUncorrectedDefectsIndividualIcExp"
+      connections.inputCatalog: "verifyDefectsIndividualIcSrc"
+      connections.uncorrectedCatalog: "verifyUncorrectedDefectsIndividualIcSrc"
       connections.outputStats: "verifyDefectsIndividualDetStats"
       connections.outputResults: "verifyDefectsIndividualDetResults"
       doVignette: false
       useReadNoise: false
       useIsrStatistics: true
+      hasMatrixCatalog: false
   verifyDefectsIndividualExp:
-    class: lsst.cp.verify.CpVerifyExpMergeTask
+    class: lsst.cp.verify.CpVerifyVisitExpMergeTask
     config:
       connections.inputStats: "verifyDefectsIndividualDetStats"
       connections.inputResults: "verifyDefectsIndividualDetResults"
       connections.outputStats: "verifyDefectsIndividualExpStats"
       connections.outputResults: "verifyDefectsIndividualExpResults"
+      mergeDimension: "visit"
+      hasInputResults: true
+      hasMatrixCatalog: false
   verifyDefectsIndividual:
-    class: lsst.cp.verify.CpVerifyRunMergeTask
+    class: lsst.cp.verify.CpVerifyVisitRunMergeTask
     config:
       connections.inputStats: "verifyDefectsIndividualExpStats"
       connections.inputResults: "verifyDefectsIndividualExpResults"
-      connections.outputStats: "verifyDefectsIndividualStats"
+      connections.outputStats: "verifyDefectsPostsFlatStats"
       connections.outputResults: "verifyDefectsIndividualResults"
+      mergeDimension: "visit"
+      hasInputResults: true
+      hasMatrixCatalog: false
 contracts:
-  - verifyDefectsIndividualDet.connections.inputExp == verifyDefectsIndividualIsr.connections.outputExposure
+  - verifyDefectsIndividualChar.connections.exposure == verifyDefectsIndividualIsr.connections.outputExposure
+  - verifyUncorrectedDefectsIndividualChar.connections.exposure == verifyUncorrectedDefectsIndividualIsr.connections.outputExposure
+  - verifyDefectsIndividualDet.connections.inputExp == verifyDefectsIndividualChar.connections.characterized
+  - verifyDefectsIndividualDet.connections.uncorrectedExp == verifyUncorrectedDefectsIndividualChar.connections.characterized
+  - verifyDefectsIndividualDet.connections.inputCatalog == verifyDefectsIndividualChar.connections.sourceCat
+  - verifyDefectsIndividualDet.connections.uncorrectedCatalog == verifyUncorrectedDefectsIndividualChar.connections.sourceCat
   - verifyDefectsIndividualExp.connections.inputStats == verifyDefectsIndividualDet.connections.outputStats
   - verifyDefectsIndividualExp.connections.inputResults == verifyDefectsIndividualDet.connections.outputResults
   - verifyDefectsIndividual.connections.inputStats == verifyDefectsIndividualExp.connections.outputStats

--- a/pipelines/_ingredients/verifyDefectsPostFlat.yaml
+++ b/pipelines/_ingredients/verifyDefectsPostFlat.yaml
@@ -20,30 +20,76 @@ tasks:
       doDefect: true
       doSaturationInterpolation: false
       growSaturationFootprintSize: 0
+      doCalculateStatistics: true
+      isrStats.doCopyCalibDistributionStatistics: true
+  verifyDefectsPostFlatChar:
+    class: lsst.pipe.tasks.characterizeImage.CharacterizeImageTask
+    config:
+      connections.exposure: "verifyDefectsPostFlatIsrExp"
+      connections.characterized: "verifyDefectsPostFlatIcExp"
+      connections.sourceCat: "verifyDefectsPostFlatIcSrc"
+      doApCorr: false
+      doDeblend: false
+      doNormalizedCalibration: false
+  verifyUncorrectedDefectsPostFlatIsr:
+    class: lsst.ip.isr.IsrTask
+    config:
+      connections.ccdExposure: "raw"
+      connections.outputExposure: "verifyUncorrectedDefectsPostFlatIsrExp"
+      doDefect: false
+      doCrosstalk: true
+  verifyUncorrectedDefectsPostFlatChar:
+    class: lsst.pipe.tasks.characterizeImage.CharacterizeImageTask
+    config:
+      connections.exposure: "verifyUncorrectedDefectsPostFlatIsrExp"
+      connections.characterized: "verifyUncorrectedDefectsPostFlatIcExp"
+      connections.sourceCat: "verifyUncorrectedDefectsPostFlatIcSrc"
+      connections.backgroundModel: "verifyUncorrectedDefectsPostFlatBackground"
+      connections.outputSchema: "verifyUncorrectedDefectsPostFlat_schema"
+      doApCorr: false
+      doDeblend: false
+      doMeasurePsf: false
+      doNormalizedCalibration: false
   verifyDefectsPostFlatDet:
     class: lsst.cp.verify.CpVerifyDefectsTask
     config:
-      connections.inputExp: "verifyDefectsPostFlatIsrExp"
+      connections.inputExp: "verifyDefectsPostFlatIcExp"
+      connections.uncorrectedExp: "verifyUncorrectedDefectsPostFlatIcExp"
+      connections.inputCatalog: "verifyDefectsPostFlatIcSrc"
+      connections.uncorrectedCatalog: "verifyUncorrectedDefectsPostFlatIcSrc"
       connections.outputStats: "verifyDefectsPostFlatDetStats"
       connections.outputResults: "verifyDefectsPostFlatDetResults"
       doVignette: false
       useReadNoise: false
+      useIsrStatistics: true
+      hasMatrixCatalog: false
   verifyDefectsPostFlatExp:
-    class: lsst.cp.verify.CpVerifyExpMergeTask
+    class: lsst.cp.verify.CpVerifyVisitExpMergeTask
     config:
       connections.inputStats: "verifyDefectsPostFlatDetStats"
       connections.inputResults: "verifyDefectsPostFlatDetResults"
       connections.outputStats: "verifyDefectsPostFlatExpStats"
       connections.outputResults: "verifyDefectsPostFlatExpResults"
+      mergeDimension: "visit"
+      hasInputResults: true
+      hasMatrixCatalog: false
   verifyDefectsPostFlat:
-    class: lsst.cp.verify.CpVerifyRunMergeTask
+    class: lsst.cp.verify.CpVerifyVisitRunMergeTask
     config:
       connections.inputStats: "verifyDefectsPostFlatExpStats"
       connections.inputResults: "verifyDefectsPostFlatExpResults"
       connections.outputStats: "verifyDefectsPostsFlatStats"
       connections.outputResults: "verifyDefectsPostFlatResults"
+      mergeDimension: "visit"
+      hasInputResults: true
+      hasMatrixCatalog: false
 contracts:
-  - verifyDefectsPostFlatDet.connections.inputExp == verifyDefectsPostFlatIsr.connections.outputExposure
+  - verifyDefectsPostFlatChar.connections.exposure == verifyDefectsPostFlatIsr.connections.outputExposure
+  - verifyUncorrectedDefectsPostFlatChar.connections.exposure == verifyUncorrectedDefectsPostFlatIsr.connections.outputExposure
+  - verifyDefectsPostFlatDet.connections.inputExp == verifyDefectsPostFlatChar.connections.characterized
+  - verifyDefectsPostFlatDet.connections.uncorrectedExp == verifyUncorrectedDefectsPostFlatChar.connections.characterized
+  - verifyDefectsPostFlatDet.connections.inputCatalog == verifyDefectsPostFlatChar.connections.sourceCat
+  - verifyDefectsPostFlatDet.connections.uncorrectedCatalog == verifyUncorrectedDefectsPostFlatChar.connections.sourceCat
   - verifyDefectsPostFlatExp.connections.inputStats == verifyDefectsPostFlatDet.connections.outputStats
   - verifyDefectsPostFlatExp.connections.inputResults == verifyDefectsPostFlatDet.connections.outputResults
   - verifyDefectsPostFlat.connections.inputStats == verifyDefectsPostFlatExp.connections.outputStats


### PR DESCRIPTION
I've duplicated the verifyDefects.yaml version to these less-well-tested pipelines.