### PR TITLE
DM-45464: Fix handling of deprecated taskMetadata

### DIFF
--- a/pipelines/_ingredients/verifyBias.yaml
+++ b/pipelines/_ingredients/verifyBias.yaml
@@ -34,7 +34,6 @@ tasks:
     class: lsst.cp.verify.CpVerifyBiasTask
     config:
       connections.inputExp: "verifyBiasIsrExp"
-      connections.taskMetadata: "verifyBiasIsr_metadata"
       connections.outputStats: "verifyBiasDetStats"
       connections.outputResults: "verifyBiasDetResults"
       connections.outputMatrix: "verifyBiasDetMatrix"

--- a/pipelines/_ingredients/verifyDark.yaml
+++ b/pipelines/_ingredients/verifyDark.yaml
@@ -16,7 +16,6 @@ tasks:
     class: lsst.cp.verify.CpVerifyDarkTask
     config:
       connections.inputExp: "verifyDarkIsrExp"
-      connections.taskMetadata: "verifyDarkIsr_metadata"
       connections.outputStats: "verifyDarkDetStats"
       connections.outputResults: "verifyDarkDetResults"
       useIsrStatistics: true

--- a/pipelines/_ingredients/verifyLinearizer.yaml
+++ b/pipelines/_ingredients/verifyLinearizer.yaml
@@ -11,7 +11,6 @@ tasks:
     class: lsst.cp.pipe.PhotonTransferCurveExtractTask
     config:
       connections.inputExp: "verifyLinearizerIsrExp"
-      connections.taskMetadata: "verifyLinearizerIsr_metadata"
       connections.outputCovariances: "verifyLinearizerPtcPartial"
   verifyLinearizerPtcSolve:
     class: lsst.cp.pipe.PhotonTransferCurveSolveTask

--- a/python/lsst/cp/verify/verifyBias.py
+++ b/python/lsst/cp/verify/verifyBias.py
@@ -47,7 +47,6 @@ class CpVerifyBiasConfig(CpVerifyStatsConfig,
                                   'NOISE': 'STDEVCLIP', }
         self.crImageStatKeywords = {'CR_NOISE': 'STDEV', }  # noqa F841
         self.metadataStatKeywords = {
-            'RESIDUAL STDEV': 'READ_NOISE',
             'LSST ISR OVERSCAN RESIDUAL SERIAL STDEV': 'READ_NOISE',
         }  # noqa F841
 

--- a/python/lsst/cp/verify/verifyDark.py
+++ b/python/lsst/cp/verify/verifyDark.py
@@ -37,7 +37,6 @@ class CpVerifyDarkConfig(CpVerifyStatsConfig,
                                   'NOISE': 'STDEVCLIP', }
         self.crImageStatKeywords = {'CR_NOISE': 'STDEV', }  # noqa F841
         self.metadataStatKeywords = {
-            'RESIDUAL STDEV': 'READ_NOISE',
             'LSST ISR OVERSCAN RESIDUAL SERIAL STDEV': 'READ_NOISE',
         }  # noqa F841
 

--- a/tests/test_verifyStats.py
+++ b/tests/test_verifyStats.py
@@ -27,8 +27,6 @@ import lsst.ip.isr.isrMock as isrMock
 import lsst.cp.verify as cpVerify
 import lsst.ip.isr.isrFunctions as isrFunctions
 
-from lsst.pipe.base import TaskMetadata
-
 
 def updateMockExp(exposure, addCR=True):
     """Update an exposure with a mask and variance plane.
@@ -211,12 +209,10 @@ class VerifyDarkTestCase(lsst.utils.tests.TestCase):
                            'detector': detector.getName(),
                            }
 
-        # Use this to test accessing info from the TaskMetadata:
-        metadataContents = TaskMetadata()
+        # Populate the READ_NOISE into the exposure header
+        md = self.inputExp.getMetadata()
         for amp in detector.getAmplifiers():
-            metadataContents[f"RESIDUAL STDEV {amp.getName()}"] = 5.24
-        self.metadata = TaskMetadata()
-        self.metadata["isr"] = metadataContents
+            md[f"LSST ISR OVERSCAN RESIDUAL SERIAL STDEV {amp.getName()}"] = 5.24
 
     def test_dark(self):
         """Test a subset of the output values to identify that the
@@ -227,7 +223,6 @@ class VerifyDarkTestCase(lsst.utils.tests.TestCase):
         task = cpVerify.CpVerifyDarkTask(config=config)
         results = task.run(self.inputExp,
                            camera=self.camera,
-                           taskMetadata=self.metadata,
                            dimensions=self.dimensions)
         darkStats = results.outputStats
 


### PR DESCRIPTION
Begin deprecation of taskMetadata in verifyStats.