### PR TITLE
DM-48380: Identify why summit OCPS is having issues with LATISS calibration checkout

### DIFF
--- a/pipelines/LATISS/verifyFlat.yaml
+++ b/pipelines/LATISS/verifyFlat.yaml
@@ -6,4 +6,5 @@ tasks:
   verifyFlatIsr:
     class: lsst.ip.isr.IsrTaskLSST
     config:
+      doBrighterFatter: false
       crosstalk.doQuadraticCrosstalkCorrection: false


### PR DESCRIPTION
Disable brighter-fatter for LATISS verifyFlat.