### PR TITLE
DM-49219: Fix cp_verify noise tests

### DIFF
--- a/python/lsst/cp/verify/verifyBias.py
+++ b/python/lsst/cp/verify/verifyBias.py
@@ -24,6 +24,7 @@ import lsst.afw.math as afwMath
 
 from lsst.geom import Point2I, Extent2I, Box2I
 from lsst.pex.config import Field
+from lsst.ip.isr.isrFunctions import getExposureReadNoises, getExposureGains
 from .verifyStats import CpVerifyStatsConfig, CpVerifyStatsTask, CpVerifyStatsConnections
 
 __all__ = ['CpVerifyBiasConfig', 'CpVerifyBiasTask']
@@ -108,6 +109,8 @@ class CpVerifyBiasTask(CpVerifyStatsTask):
 
         verifyStats = {}
         success = True
+        gains = getExposureGains(exposure)
+        readNoises = getExposureReadNoises(exposure)
         for ampName, stats in ampStats.items():
             verify = {}
 
@@ -128,7 +131,7 @@ class CpVerifyBiasTask(CpVerifyStatsTask):
             # measured on the bulk of the image as the overscan
             # correction should be an optimal fit to the overscan
             # region, but not necessarily for the image region.
-            readNoise = exposure.getMetadata().get(f"LSST ISR READNOISE {ampName}", np.nan)
+            readNoise = readNoises[ampName]
             verify['NOISE'] = bool((stats['NOISE'] - readNoise)/readNoise <= 0.05)
 
             # DMTN-101 Test 4.4: CR rejection matches clipped mean.
@@ -152,7 +155,7 @@ class CpVerifyBiasTask(CpVerifyStatsTask):
             # if the metadataStats contain the required entry.  This
             # is in ADU (the serial overscan is measured prior to gain
             # normalization), so we need to convert to electrons here.
-            gain = exposure.getMetadata().get(f"LSST ISR GAIN {ampName}", np.nan)
+            gain = gains[ampName]
             overscanReadNoise = gain * metadataStats['READ_NOISE'][ampName]
             if overscanReadNoise:
                 if ((overscanReadNoise - readNoise)/readNoise > 0.05) or not np.isfinite(overscanReadNoise):

--- a/python/lsst/cp/verify/verifyBias.py
+++ b/python/lsst/cp/verify/verifyBias.py
@@ -157,6 +157,8 @@ class CpVerifyBiasTask(CpVerifyStatsTask):
             if overscanReadNoise:
                 if ((overscanReadNoise - readNoise)/readNoise > 0.05) or not np.isfinite(overscanReadNoise):
                     verify['READ_NOISE_CONSISTENT'] = False
+                else:
+                    verify['READ_NOISE_CONSISTENT'] = True
 
             verifyStats[ampName] = verify
 

--- a/python/lsst/cp/verify/verifyDark.py
+++ b/python/lsst/cp/verify/verifyDark.py
@@ -122,6 +122,8 @@ class CpVerifyDarkTask(CpVerifyStatsTask):
             if overscanReadNoise:
                 if ((overscanReadNoise - readNoise)/readNoise > 0.05) or not np.isfinite(overscanReadNoise):
                     verify['READ_NOISE_CONSISTENT'] = False
+                else:
+                    verify['READ_NOISE_CONSISTENT'] = True
 
             verifyStats[ampName] = verify
 

--- a/python/lsst/cp/verify/verifyDark.py
+++ b/python/lsst/cp/verify/verifyDark.py
@@ -38,7 +38,7 @@ class CpVerifyDarkConfig(CpVerifyStatsConfig,
                                   'NOISE': 'STDEVCLIP', }
         self.crImageStatKeywords = {'CR_NOISE': 'STDEV', }  # noqa F841
         self.metadataStatKeywords = {
-            'LSST ISR OVERSCAN RESIDUAL SERIAL STDEV': 'READ_NOISE',
+            'LSST ISR OVERSCAN RESIDUAL SERIAL STDEV': 'READ_NOISE_ADU',
         }  # noqa F841
 
 
@@ -74,29 +74,34 @@ class CpVerifyDarkTask(CpVerifyStatsTask):
 
         verifyStats = {}
         success = True
-        gains = getExposureGains(exposure)
-        readNoises = getExposureReadNoises(exposure)
+        # These are the PTC gain and RN (e-) used in constructing the
+        # variance plane:
+        gainDict = getExposureGains(exposure)
+        readNoiseDict = getExposureReadNoises(exposure)
         for ampName, stats in ampStats.items():
             verify = {}
 
-            # DMTN-101 Test 5.2: Mean is 0.0:
+            # DMTN-101 Test 5.2: Mean is 0.0 within the noise measured
+            # on the image (e-):
             verify['MEAN'] = bool(np.abs(stats['MEAN']) < stats['NOISE'])
 
-            # DMTN-101 Test 5.3: Clipped mean matches readNoise.  This
-            # test should use the nominal detector read noise.  The
-            # f"READ_NOISE" metadata entry contains the
-            # measured dispersion in the overscan-corrected overscan
-            # region, which should provide an estimate of the read
-            # noise.  However, directly using this value will cause
-            # some fraction of verification runs to fail if the
-            # scatter in read noise values is comparable to the test
-            # threshold, as the overscan residual measured may be
-            # sampling from the low end tail of the distribution.
-            # This measurement is also likely to be smaller than that
-            # measured on the bulk of the image as the overscan
-            # correction should be an optimal fit to the overscan
-            # region, but not necessarily for the image region.
-            readNoise = readNoises[ampName]
+            # DMTN-101 Test 5.3: Clipped mean matches nominal PTC
+            # readNoise.  This test should use the nominal detector
+            # read noise.  The f"READ_NOISE_ADU" metadata entry
+            # contains the measured dispersion in the
+            # overscan-corrected overscan region, which should provide
+            # an estimate of the read noise (in ADU).  However,
+            # directly using this value will cause some fraction of
+            # verification runs to fail if the scatter in read noise
+            # values is comparable to the test threshold, as the
+            # overscan residual measured may be sampling from the low
+            # end tail of the distribution.  This measurement is also
+            # likely to be smaller than that measured on the bulk of
+            # the image as the overscan correction should be an
+            # optimal fit to the overscan region, but not necessarily
+            # for the image region.  We check read noise consistency
+            # below.
+            readNoise = readNoiseDict[ampName]
             verify['NOISE'] = bool((stats['NOISE'] - readNoise)/readNoise <= 0.05)
 
             # DMTN-101 Test 5.4: CR rejection matches clipped mean
@@ -120,8 +125,8 @@ class CpVerifyDarkTask(CpVerifyStatsTask):
             # if the metadataStats contain the required entry.  This
             # is in ADU (the serial overscan is measured prior to gain
             # normalization), so we need to convert to electrons here.
-            gain = gains[ampName]
-            overscanReadNoise = gain * metadataStats['READ_NOISE'][ampName]
+            gain = gainDict[ampName]
+            overscanReadNoise = gain * metadataStats['READ_NOISE_ADU'][ampName]
             if overscanReadNoise:
                 if ((overscanReadNoise - readNoise)/readNoise > 0.05) or not np.isfinite(overscanReadNoise):
                     verify['READ_NOISE_CONSISTENT'] = False
@@ -164,8 +169,8 @@ class CpVerifyDarkTask(CpVerifyStatsTask):
                 rows[ampName][f"{self.config.stageName}_VERIFY_{key}"] = value
 
         # METADATA results
-        for ampName, value in statisticsDict["METADATA"]["READ_NOISE"].items():
-            rows[ampName][f"{self.config.stageName}_READ_NOISE"] = value
+        for ampName, value in statisticsDict["METADATA"]["READ_NOISE_ADU"].items():
+            rows[ampName][f"{self.config.stageName}_READ_NOISE_ADU"] = value
 
         # ISR results
         if self.config.useIsrStatistics and "ISR" in statisticsDict:

--- a/python/lsst/cp/verify/verifyDark.py
+++ b/python/lsst/cp/verify/verifyDark.py
@@ -68,7 +68,6 @@ class CpVerifyDarkTask(CpVerifyStatsTask):
         success : `bool`
             A boolean indicating if all tests have passed.
         """
-        detector = exposure.getDetector()
         ampStats = statisticsDict['AMP']
         metadataStats = statisticsDict['METADATA']
 
@@ -94,7 +93,7 @@ class CpVerifyDarkTask(CpVerifyStatsTask):
             # measured on the bulk of the image as the overscan
             # correction should be an optimal fit to the overscan
             # region, but not necessarily for the image region.
-            readNoise = detector[ampName].getReadNoise()
+            readNoise = exposure.getMetadata().get(f"LSST ISR READNOISE {ampName}", np.nan)
             verify['NOISE'] = bool((stats['NOISE'] - readNoise)/readNoise <= 0.05)
 
             # DMTN-101 Test 5.4: CR rejection matches clipped mean
@@ -115,8 +114,11 @@ class CpVerifyDarkTask(CpVerifyStatsTask):
             # consistently and significantly, then the assumptions
             # used in that test may be incorrect, and the nominal read
             # noise may need recalculation.  Only perform this check
-            # if the metadataStats contain the required entry.
-            overscanReadNoise = metadataStats['READ_NOISE'][ampName]
+            # if the metadataStats contain the required entry.  This
+            # is in ADU (the serial overscan is measured prior to gain
+            # normalization), so we need to convert to electrons here.
+            gain = exposure.getMetadata().get(f"LSST ISR GAIN {ampName}", np.nan)
+            overscanReadNoise = gain * metadataStats['READ_NOISE'][ampName]
             if overscanReadNoise:
                 if ((overscanReadNoise - readNoise)/readNoise > 0.05) or not np.isfinite(overscanReadNoise):
                     verify['READ_NOISE_CONSISTENT'] = False

--- a/tests/test_verifyStats.py
+++ b/tests/test_verifyStats.py
@@ -177,7 +177,7 @@ class VerifyBiasTestCase(lsst.utils.tests.TestCase):
         self.assertAlmostEqual(biasStats['AMP']['C:0,0']['NOISE'], 13.99547, 4)
         self.assertAlmostEqual(biasStats['AMP']['C:0,0']['CR_NOISE'], 14.11526, 4)
         # This order swap in intended. :sad-panda-emoji:
-        self.assertAlmostEqual(biasStats['METADATA']['READ_NOISE']['C:0,0'], 4.25)
+        self.assertAlmostEqual(biasStats['METADATA']['READ_NOISE_ADU']['C:0,0'], 4.25)
 
         self.assertIn(biasStats['SUCCESS'], [True, False])
 
@@ -209,7 +209,7 @@ class VerifyDarkTestCase(lsst.utils.tests.TestCase):
                            'detector': detector.getName(),
                            }
 
-        # Populate the READ_NOISE into the exposure header
+        # Populate the READ_NOISE (in ADU) into the exposure header
         md = self.inputExp.getMetadata()
         for amp in detector.getAmplifiers():
             md[f"LSST ISR OVERSCAN RESIDUAL SERIAL STDEV {amp.getName()}"] = 5.24
@@ -230,7 +230,7 @@ class VerifyDarkTestCase(lsst.utils.tests.TestCase):
         self.assertAlmostEqual(darkStats['AMP']['C:0,0']['NOISE'], 3.12948, 4)
         self.assertAlmostEqual(darkStats['AMP']['C:0,0']['CR_NOISE'], 3.15946, 4)
         # This order swap in intended. :sad-panda-emoji:
-        self.assertAlmostEqual(darkStats['METADATA']['READ_NOISE']['C:0,0'], 5.24)
+        self.assertAlmostEqual(darkStats['METADATA']['READ_NOISE_ADU']['C:0,0'], 5.24)
 
         self.assertIn(darkStats['SUCCESS'], [True, False])
 


### PR DESCRIPTION
This switches to use the calculated header values.