### PR TITLE
DM-49369: Update LSST illumination correction configurations

### DIFF
--- a/pipelines/_ingredients/verifyIlluminationCorrectionLSST.yaml
+++ b/pipelines/_ingredients/verifyIlluminationCorrectionLSST.yaml
@@ -4,16 +4,16 @@ tasks:
     class: lsst.ip.isr.IsrTaskLSST
     config:
       doAmpOffset: false
-      connections.outputExposure: "postISRCCD"
+      connections.outputExposure: "post_isr_image"
   verifyIlluminationCorrectionCalibrateImage:
     class: lsst.pipe.tasks.calibrateImage.CalibrateImageTask
     config:
-      connections.exposures: "postISRCCD"
-      connections.initial_stars_schema: "src_schema"
-      connections.stars_footprints: "src"
-      connections.stars: "preSource"
-      connections.exposure: "calexp"
-      connections.background: "calexpBackground"
+      connections.exposures: "post_isr_image"
+      connections.initial_stars_schema: "single_visit_star_schema"
+      connections.stars_footprints: "single_visit_star_footprints"
+      connections.stars: "single_visit_star_unstandardized"
+      connections.exposure: "preliminary_visit_image"
+      connections.background: "preliminary_visit_image_background"
       do_calibrate_pixels: false
       # Ensure that all illumination correction parameters are turned
       # on when verifying them.
@@ -41,18 +41,25 @@ tasks:
     class: lsst.pipe.tasks.postprocess.TransformSourceTableTask
     config:
       functorFile: "$CP_PIPE_DIR/schemas/PreSourceIlluminationCorrection.yaml"
-      connections.inputCatalog: "preSource"
-      connections.outputCatalog: "preSourceTable"
+      connections.inputCatalog: "single_visit_star_unstandardized"
+      connections.outputCatalog: "single_visit_star_detector"
   verifyIlluminationCorrectionConsolidatePreSourceTable:
     class: lsst.pipe.tasks.postprocess.ConsolidateSourceTableTask
     config:
-      connections.inputCatalogs: "preSourceTable"
-      connections.outputCatalog: "preSourceTable_visit"
-  verifyIlluminationCorrectionConsolidateVisitSummary: lsst.pipe.tasks.postprocess.ConsolidateVisitSummaryTask
+      connections.inputCatalogs: "single_visit_star_detector"
+      connections.outputCatalog: "single_visit_star"
+  verifyIlluminationCorrectionConsolidateVisitSummary:
+    class: lsst.pipe.tasks.postprocess.ConsolidateVisitSummaryTask
+    config:
+      connections.calexp: "preliminary_visit_image"
+      connections.visitSummary: "preliminary_visit_summary"
+      connections.visitSummarySchema: "preliminary_visit_summary_schema"
   verifyIlluminationCorrectionIsolatedStarAssociation:
     class: lsst.pipe.tasks.isolatedStarAssociation.IsolatedStarAssociationTask
     config:
-      connections.source_table_visit: "preSourceTable_visit"
+      connections.source_table_visit: "single_visit_star"
+      connections.isolated_star_sources: "isolated_star"
+      connections.isolated_star_cat: "isolated_star_association"
       python: |
         config.extra_columns = [
           "x",
@@ -67,6 +74,9 @@ tasks:
   verifyIlluminationCorrectionFgcmBuildFromIsolatedStars:
     class: lsst.fgcmcal.fgcmBuildFromIsolatedStars.FgcmBuildFromIsolatedStarsTask
     config:
+      connections.isolated_star_cats: "isolated_star_association"
+      connections.isolated_star_sources: "isolated_star"
+      connections.visit_summaries: "preliminary_visit_summary"
       doApplyWcsJacobian: false
       densityCutMaxPerPixel: 1000000
   verifyIlluminationCorrectionFgcmFitCycle:

--- a/pipelines/_ingredients/verifyIlluminationCorrectionLSST.yaml
+++ b/pipelines/_ingredients/verifyIlluminationCorrectionLSST.yaml
@@ -68,6 +68,7 @@ tasks:
     class: lsst.fgcmcal.fgcmBuildFromIsolatedStars.FgcmBuildFromIsolatedStarsTask
     config:
       doApplyWcsJacobian: false
+      densityCutMaxPerPixel: 1000000
   verifyIlluminationCorrectionFgcmFitCycle:
     class: lsst.fgcmcal.fgcmFitCycle.FgcmFitCycleTask
     config:

--- a/pipelines/_ingredients/verifyIlluminationCorrectionLSST.yaml
+++ b/pipelines/_ingredients/verifyIlluminationCorrectionLSST.yaml
@@ -85,6 +85,7 @@ tasks:
       doMultipleCycles: true
       multipleCyclesFinalCycleNumber: 5
       superStarForceZeroMean: true
+      superStarSubCcdChebyshevOrder: 4
   verifyIlluminationCorrectionFgcmOutputIlluminationCorrection:
     class: lsst.fgcmcal.fgcmOutputIlluminationCorrection.FgcmOutputIlluminationCorrectionTask
     config:


### PR DESCRIPTION
This updates the density cut which had been erroneously applied; changes to 4th order chebyshev polynomials (per detector); and updates to v2 connection dataset type names.